### PR TITLE
feat(initramfs): accept other media types

### DIFF
--- a/initramfs/src/httpclient.rs
+++ b/initramfs/src/httpclient.rs
@@ -1,14 +1,24 @@
 use anyhow::{anyhow, Result};
 use reqwest::{Client, Response};
 
-pub async fn run_get_request(url: &str, token: Option<&str>) -> Result<Response> {
-    let res = match token {
+pub async fn run_get_request(
+    url: &str,
+    token: Option<&String>,
+    headers: Vec<(String, String)>,
+) -> Result<Response> {
+    let mut res = match token {
         Some(token) => Client::new().get(url).bearer_auth(token),
         None => Client::new().get(url),
+    };
+
+    for (key, value) in headers {
+        res = res.header(key, value);
     }
-    .send()
-    .await
-    .map_err(|e| anyhow!(e).context(format!("Failed to run request to {}", url)))?;
+
+    let res = res
+        .send()
+        .await
+        .map_err(|e| anyhow!(e).context(format!("Failed to run request to {}", url)))?;
 
     if !res.status().is_success() {
         return Err(anyhow!(res.text().await.unwrap_or_default())

--- a/initramfs/src/main.rs
+++ b/initramfs/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     debug!("Running cli with arguments : {:?}", args);
 
-    let registry = Registry::new(&args.registry_url, &args.auth_url);
+    let mut registry = Registry::new(&args.registry_url, &args.auth_url);
 
     info!("Downloading image {}", &args.image);
     let image = registry.get_image(&args.image).await?;


### PR DESCRIPTION
We used to only accept the old ManifestV1 response type. However, most images don't come with this manifest type anymore, but instead has a ManifestV2 List / OCI Spec'd manifest.

This PR adds handling of those manifests types:
- OCI List
- ManifestV2 List
- ManifestV2